### PR TITLE
re-add customized changes

### DIFF
--- a/classes/bot.py
+++ b/classes/bot.py
@@ -22,6 +22,7 @@ class ModMail(commands.AutoShardedBot):
         self.session = aiohttp.ClientSession(loop=self.loop)
         self.cluster = kwargs.get("cluster_id")
         self.cluster_count = kwargs.get("cluster_count")
+        self.activity = discord.Activity(name=config.activity, type=discord.ActivityType.watching)
         self.version = kwargs.get("version")
 
     @property

--- a/cogs/core.py
+++ b/cogs/core.py
@@ -27,7 +27,7 @@ class Core(commands.Cog):
         usage="reply <message>",
         aliases=["r"]
     )
-    async def reply(self, ctx, *, message):
+    async def reply(self, ctx, *, message: str = None):
         await self.bot.cogs["ModMailEvents"].send_mail_mod(ctx.message, ctx.prefix, False, message)
 
     @checks.is_modmail_channel()

--- a/cogs/modmail_channel.py
+++ b/cogs/modmail_channel.py
@@ -17,8 +17,16 @@ class ModMailEvents(commands.Cog):
 
     @commands.Cog.listener()
     async def on_message(self, message):
+        if message.guild.me in message.mentions:
+            return await message.channel.send(f'To open a ModMail ticket please PM me details of your issue.')
+
+        return
+        # revision Sep 19 - no longer want a reply created if an attachment is sent solo, so might not be any reason for this function
+        # other than the auto-reply
+
         if message.author.bot or not message.guild or not checks.is_modmail_channel2(self.bot, message.channel):
             return
+
         if (
             message.channel.permissions_for(message.guild.me).send_messages is False
             or message.channel.permissions_for(message.guild.me).embed_links is False
@@ -74,7 +82,8 @@ class ModMailEvents(commands.Cog):
         try:
             embed = discord.Embed(
                 title="Message Received",
-                description=message.content if msg is None else msg,
+                # description=message.content if msg is None else msg,
+                description='' if msg is None else msg,
                 colour=self.bot.mod_colour,
                 timestamp=datetime.datetime.utcnow(),
             )

--- a/utils/prometheus.py
+++ b/utils/prometheus.py
@@ -19,11 +19,15 @@ class Prometheus:
         self.ticks = os.sysconf("SC_CLK_TCK")
         self.btime = 0
 
-        with open(os.path.join("/proc", "stat"), "rb") as stat:
-            for line in stat:
-                if line.startswith(b"btime "):
-                    self.btime = float(line.split()[1])
-                    break
+        try:
+            with open(os.path.join("/proc", "stat"), "rb") as stat:
+                for line in stat:
+                    if line.startswith(b"btime "):
+                        self.btime = float(line.split()[1])
+                        break
+        except FileNotFoundError:
+            # Handling exception here that base code does not since /proc/stat does not exist on MacOS
+            pass
 
         self.vmem = Gauge("process_virtual_memory_bytes", "Virtual memory size in bytes.")
         self.rss = Gauge("process_resident_memory_bytes", "Resident memory size in bytes.")


### PR DESCRIPTION
bot presence, ignore single images, checking banned role. error handling for a macos-specific error. 